### PR TITLE
Renaming argument of `Retry` that has been deprecated with urllib3  [v2.0.0]

### DIFF
--- a/best_download/__init__.py
+++ b/best_download/__init__.py
@@ -36,7 +36,7 @@ retry_strategy = Retry(
     total=3,
     backoff_factor=1,
     status_forcelist=[429, 500, 502, 503, 504],
-    method_whitelist=["HEAD", "GET", "OPTIONS"]
+    allowed_methods=["HEAD", "GET", "OPTIONS"]
 )
 adapter = HTTPAdapter(max_retries=retry_strategy)
 session = requests.Session()


### PR DESCRIPTION
Renaming argument of `Retry` that has been deprecated with urllib3  [v2.0.0](https://github.com/urllib3/urllib3/releases/tag/2.0.0)

Fixes #3 